### PR TITLE
Include PDF and HTML reports in files Linguist should ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.Rmd linguist-language=R
-reports/* linguist-vendored
-events_analysis/*.nb.html linguist-vendored=True
+reports/* linguist-documentation
+*.html linguist-documentation=True
+*.pdf linguist-documentation=True


### PR DESCRIPTION
This ensures that GitHub identifies the repo language correctly

Part of Issue #63

Signed-off-by: Augustina Ragwitz <augustina.ragwitz@ibm.com>